### PR TITLE
added support for podman desktop

### DIFF
--- a/canned/clustered_redis.go
+++ b/canned/clustered_redis.go
@@ -3,14 +3,15 @@ package canned
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/go-redis/redis/v8"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
-	"strconv"
-	"time"
 )
 
 type ClusteredRedis struct {
@@ -56,6 +57,7 @@ func NewClusteredRedis() (*ClusteredRedis, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 	if err != nil {
 		return nil, err

--- a/canned/consul.go
+++ b/canned/consul.go
@@ -3,11 +3,12 @@ package canned
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/docker/docker/client"
 	"github.com/hashicorp/consul/api"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
 )
 
 type Consul struct {
@@ -33,6 +34,7 @@ func NewConsul(ctx context.Context) (*Consul, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/dynamodb.go
+++ b/canned/dynamodb.go
@@ -3,6 +3,10 @@ package canned
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -12,9 +16,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/net/http2"
-	"net"
-	"net/http"
-	"os"
 )
 
 type DynamoDB struct {
@@ -43,6 +44,7 @@ func NewDynamoDB(ctx context.Context) (*DynamoDB, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -3,11 +3,12 @@ package canned
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
-	"time"
 )
 
 type ElasticSearch struct {
@@ -31,6 +32,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 	if err != nil {
 		return nil, err

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -28,6 +28,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 		ExposedPorts: []string{"9200/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		RegistryCred: getBasicAuth(),
+		SkipReaper:   skipReaper(),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/canned/kafka.go
+++ b/canned/kafka.go
@@ -3,9 +3,10 @@ package canned
 import (
 	"context"
 	"fmt"
-	"github.com/testcontainers/testcontainers-go"
 	"os"
 	"strconv"
+
+	"github.com/testcontainers/testcontainers-go"
 
 	confluent "github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/docker/docker/client"
@@ -57,6 +58,7 @@ func NewKafka(ctx context.Context) (*Kafka, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 	if err != nil {
 		return nil, err

--- a/canned/localstack.go
+++ b/canned/localstack.go
@@ -3,6 +3,10 @@ package canned
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -10,9 +14,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/net/http2"
-	"net"
-	"net/http"
-	"os"
 )
 
 type Localstack struct {
@@ -41,6 +42,7 @@ func NewLocalstack(ctx context.Context) (*Localstack, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/minio.go
+++ b/canned/minio.go
@@ -3,6 +3,8 @@ package canned
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -12,7 +14,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
 )
 
 type Minio struct {
@@ -48,6 +49,7 @@ func NewMinio(ctx context.Context) (*Minio, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/mysql.go
+++ b/canned/mysql.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+
 	"github.com/docker/docker/client"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
 )
 
 type Mysql struct {
@@ -41,6 +42,7 @@ func NewMysql(ctx context.Context) (*Mysql, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 	if err != nil {
 		return nil, err

--- a/canned/redis.go
+++ b/canned/redis.go
@@ -37,6 +37,7 @@ func NewRedis(ctx context.Context) (*Redis, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/sqs.go
+++ b/canned/sqs.go
@@ -3,6 +3,10 @@ package canned
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -12,9 +16,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/net/http2"
-	"net"
-	"net/http"
-	"os"
 )
 
 type SQS struct {
@@ -43,6 +44,7 @@ func NewSQS(ctx context.Context) (*SQS, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/tile38.go
+++ b/canned/tile38.go
@@ -36,6 +36,7 @@ func NewTile38(ctx context.Context) (*Tile38, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {

--- a/canned/util.go
+++ b/canned/util.go
@@ -5,16 +5,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/docker/docker/api/types"
 	"math/rand"
 	"net"
 	"os"
 	"strconv"
+
+	"github.com/docker/docker/api/types"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 func skipReaper() bool {
 	val, _ := strconv.ParseBool(os.Getenv("TESTCONTAINERS_RYUK_DISABLED"))
 	return val
+}
+func testContainerProvider() testcontainers.ProviderType {
+	val := os.Getenv("TESTCONTAINERS_PROVIDER")
+	if val == "podman" {
+		return testcontainers.ProviderPodman
+	}
+	return testcontainers.ProviderDocker
 }
 
 func getEnvString(variable string, defaultValue string) string {

--- a/canned/wiremock.go
+++ b/canned/wiremock.go
@@ -3,10 +3,11 @@ package canned
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/docker/docker/client"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"os"
 )
 
 type WireMock struct {
@@ -33,6 +34,7 @@ func NewWiremock(ctx context.Context) (*WireMock, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		ProviderType:     testContainerProvider(),
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR adds support for podman desktop by adding provider as podman via an environment variable. This has been tested with both docker desktop and podman.
The tests pass successfully as well

sh-3.2$ go clean -testcache
sh-3.2$ go test ./...
?       github.com/Swiggy/grill/canned  [no test files]
?       github.com/Swiggy/grill/mock    [no test files]
ok      github.com/Swiggy/grill 1.445s
?       github.com/Swiggy/grill/pkg/grillgrpc/hello     [no test files]
ok      github.com/Swiggy/grill/pkg/grillclusteredredis 31.063s
ok      github.com/Swiggy/grill/pkg/grillconsul 5.020s
ok      github.com/Swiggy/grill/pkg/grilldynamo 16.205s
ok      github.com/Swiggy/grill/pkg/grillelasticsearch  65.420s
ok      github.com/Swiggy/grill/pkg/grillgrpc   2.015s
ok      github.com/Swiggy/grill/pkg/grillhttp   13.618s
ok      github.com/Swiggy/grill/pkg/grillkafka  109.795s
ok      github.com/Swiggy/grill/pkg/grillmysql  45.133s
ok      github.com/Swiggy/grill/pkg/grillredis  9.855s
ok      github.com/Swiggy/grill/pkg/grills3     132.969s
ok      github.com/Swiggy/grill/pkg/grillsqs    40.907s
ok      github.com/Swiggy/grill/pkg/grilltile38 9.878s


And we will raise a separate PR to update the wiki