### PR TITLE
Es fix

### DIFF
--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -22,12 +22,13 @@ type ElasticSearch struct {
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
 	req := testcontainers.ContainerRequest{
-		Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.17.9"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2"),
 		Env: map[string]string{
 			"discovery.type": "single-node"},
 		ExposedPorts: []string{"9200/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		RegistryCred: getBasicAuth(),
+		AutoRemove:   true,
 		SkipReaper:   skipReaper(),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -30,10 +30,10 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 			"network.bind_host": "0.0.0.0",
 		},
 		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
-		//WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
-		WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
+		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
+		//WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
 		RegistryCred: getBasicAuth(),
-		AutoRemove:   true,
+		//AutoRemove:   true,
 		SkipReaper:   skipReaper(),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -25,16 +25,16 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
 		//Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
 		Env: map[string]string{
-			"discovery.type":    "single-node",
-			"network.host":      "0.0.0.0",
-			"network.bind_host": "0.0.0.0",
+			"discovery.type": "single-node",
+			//"network.host":      "0.0.0.0",
+			//"network.bind_host": "0.0.0.0",
 		},
 		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		//WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
 		RegistryCred: getBasicAuth(),
 		//AutoRemove:   true,
-		SkipReaper:   skipReaper(),
+		SkipReaper: skipReaper(),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -54,7 +54,8 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{endpoint},
+		Addresses:            []string{endpoint},
+		EnableRetryOnTimeout: true,
 	})
 	if err != nil {
 		return nil, err

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -29,7 +29,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 			"network.host":      "0.0.0.0",
 			"network.bind_host": "0.0.0.0",
 		},
-		ExposedPorts: []string{"9200/tcp"},
+		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		//WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
 		RegistryCred: getBasicAuth(),

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -22,14 +22,16 @@ type ElasticSearch struct {
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
 	req := testcontainers.ContainerRequest{
-		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
+		//Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.0.0"),
 		Env: map[string]string{
 			"discovery.type":    "single-node",
 			"network.host":      "0.0.0.0",
 			"network.bind_host": "0.0.0.0",
 		},
-		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
-		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
+		ExposedPorts: []string{"9200/tcp"},
+		//WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
+		WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
 		RegistryCred: getBasicAuth(),
 		AutoRemove:   true,
 		SkipReaper:   skipReaper(),

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -21,33 +21,17 @@ type ElasticSearch struct {
 
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
-	//volumeConfig := map[string]string{
-	//	"host-path":      "my_es_data",
-	//	"container-path": "/usr/share/elasticsearch/data",
-	//}
 	req := testcontainers.ContainerRequest{
-		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
-		//Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.0.0"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.0.0"),
 		Env: map[string]string{
 			"discovery.type":    "single-node",
 			"network.host":      "0.0.0.0",
 			"network.bind_host": "0.0.0.0",
 		},
-		//Mounts: testcontainers.ContainerMounts{
-		//	{
-		//		Source: testcontainers.GenericVolumeMountSource{
-		//			Name: volumeConfig["host-path"],
-		//		},
-		//		Target:   testcontainers.ContainerMountTarget(volumeConfig["container-path"]),
-		//		ReadOnly: false,
-		//	},
-		//},
 		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
-		//WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
 		RegistryCred: getBasicAuth(),
-		//AutoRemove:   true,
-		SkipReaper: skipReaper(),
+		SkipReaper:   skipReaper(),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -59,8 +43,6 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 	host, _ := container.Host(ctx)
 	port, _ := container.MappedPort(ctx, "9200")
-	//port2, _ := container.MappedPort(ctx, "9300")
-	//endpoint, err := container.Endpoint(ctx, "")
 	endpoint := fmt.Sprintf("http://%s:%s", host, port.Port())
 
 	if err != nil {
@@ -68,7 +50,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses:            []string{endpoint}, //, fmt.Sprintf("http://%s:%s", host, port2.Port())},
+		Addresses:            []string{endpoint},
 		EnableRetryOnTimeout: true,
 	})
 	if err != nil {

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -21,14 +21,27 @@ type ElasticSearch struct {
 
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
+	//volumeConfig := map[string]string{
+	//	"host-path":      "my_es_data",
+	//	"container-path": "/usr/share/elasticsearch/data",
+	//}
 	req := testcontainers.ContainerRequest{
 		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
-		//Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
+		//Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.0.0"),
 		Env: map[string]string{
 			"discovery.type":    "single-node",
 			"network.host":      "0.0.0.0",
 			"network.bind_host": "0.0.0.0",
 		},
+		//Mounts: testcontainers.ContainerMounts{
+		//	{
+		//		Source: testcontainers.GenericVolumeMountSource{
+		//			Name: volumeConfig["host-path"],
+		//		},
+		//		Target:   testcontainers.ContainerMountTarget(volumeConfig["container-path"]),
+		//		ReadOnly: false,
+		//	},
+		//},
 		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		//WaitingFor:   wait.ForHTTP("/").WithPort("9200/tcp").WithStartupTimeout(time.Minute * 3),
@@ -46,16 +59,16 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 	host, _ := container.Host(ctx)
 	port, _ := container.MappedPort(ctx, "9200")
-	port2, _ := container.MappedPort(ctx, "9300")
-	endpoint, err := container.Endpoint(ctx, "")
-	endpoint = fmt.Sprintf("http://%s", endpoint)
+	//port2, _ := container.MappedPort(ctx, "9300")
+	//endpoint, err := container.Endpoint(ctx, "")
+	endpoint := fmt.Sprintf("http://%s:%s", host, port.Port())
 
 	if err != nil {
 		return nil, err
 	}
 
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses:            []string{endpoint, fmt.Sprintf("http://%s:%s", host, port2.Port())},
+		Addresses:            []string{endpoint}, //, fmt.Sprintf("http://%s:%s", host, port2.Port())},
 		EnableRetryOnTimeout: true,
 	})
 	if err != nil {

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -22,8 +22,8 @@ type ElasticSearch struct {
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
 	req := testcontainers.ContainerRequest{
-		//Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
-		Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
+		//Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
 		Env: map[string]string{
 			"discovery.type":    "single-node",
 			"network.host":      "0.0.0.0",

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -22,10 +22,13 @@ type ElasticSearch struct {
 func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
 	req := testcontainers.ContainerRequest{
-		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
 		Env: map[string]string{
-			"discovery.type": "single-node"},
-		ExposedPorts: []string{"9200/tcp"},
+			"discovery.type":    "single-node",
+			"network.host":      "0.0.0.0",
+			"network.bind_host": "0.0.0.0",
+		},
+		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
 		RegistryCred: getBasicAuth(),
 		AutoRemove:   true,

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -23,7 +23,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	_ = os.Setenv("TC_HOST", "localhost")
 	req := testcontainers.ContainerRequest{
 		//Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
-		Image: getEnvString("ES_CONTAINER_IMAGE", "elasticsearch:7.0.0"),
+		Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
 		Env: map[string]string{
 			"discovery.type":    "single-node",
 			"network.host":      "0.0.0.0",

--- a/canned/elasticsearch.go
+++ b/canned/elasticsearch.go
@@ -25,9 +25,9 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 		Image: getEnvString("ES_CONTAINER_IMAGE", "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"),
 		//Image: getEnvString("ES_CONTAINER_IMAGE", "157529275398.dkr.ecr.ap-south-1.amazonaws.com/ci-libraries/docker.elastic.co/elasticsearch/elasticsearch:6.4.2"),
 		Env: map[string]string{
-			"discovery.type": "single-node",
-			//"network.host":      "0.0.0.0",
-			//"network.bind_host": "0.0.0.0",
+			"discovery.type":    "single-node",
+			"network.host":      "0.0.0.0",
+			"network.bind_host": "0.0.0.0",
 		},
 		ExposedPorts: []string{"9200/tcp", "9300/tcp"},
 		WaitingFor:   wait.ForListeningPort("9200").WithStartupTimeout(time.Minute * 3), // Default timeout is 1 minute
@@ -46,6 +46,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 	host, _ := container.Host(ctx)
 	port, _ := container.MappedPort(ctx, "9200")
+	port2, _ := container.MappedPort(ctx, "9300")
 	endpoint, err := container.Endpoint(ctx, "")
 	endpoint = fmt.Sprintf("http://%s", endpoint)
 
@@ -54,7 +55,7 @@ func NewElasticSearch(ctx context.Context) (*ElasticSearch, error) {
 	}
 
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses:            []string{endpoint},
+		Addresses:            []string{endpoint, fmt.Sprintf("http://%s:%s", host, port2.Port())},
 		EnableRetryOnTimeout: true,
 	})
 	if err != nil {

--- a/pkg/grillelasticsearch/stubs.go
+++ b/pkg/grillelasticsearch/stubs.go
@@ -12,8 +12,10 @@ import (
 func (ge *ElasticSearch) CreateIndex(index string, mapping string) grill.Stub {
 	return grill.StubFunc(func() error {
 		req := esapi.IndicesCreateRequest{
-			Index: index,
-			Body:  strings.NewReader(mapping),
+			Index:         index,
+			MasterTimeout: 3000,
+			Timeout:       3000,
+			Body:          strings.NewReader(mapping),
 		}
 		res, err := req.Do(context.Background(), ge.elasticSearch.Client)
 		if err != nil {


### PR DESCRIPTION
grill ES SLTs was failing almost everytime. probably, Two reasons of failing are : image takes ~34 sec to get ready and port is not always available.

to fix it,
lighter image added that takes ~10 sec and port addition is done.