### PR TITLE
Assign a Static Port to Minio Console and Expose it.

### DIFF
--- a/canned/minio.go
+++ b/canned/minio.go
@@ -34,9 +34,9 @@ func NewMinio(ctx context.Context) (*Minio, error) {
 
 	req := testcontainers.ContainerRequest{
 		Image:        getEnvString("MINIO_CONTAINER_IMAGE", "minio/minio:RELEASE.2023-05-18T00-05-36Z"),
-		ExposedPorts: []string{"9000/tcp"},
+		ExposedPorts: []string{"9000/tcp", "9001/tcp"},
 		WaitingFor:   wait.ForListeningPort("9000/tcp"),
-		Cmd:          []string{"server", "/data"},
+		Cmd:          []string{"server", "/data", "--console-address", ":9001"},
 		Env: map[string]string{
 			"MINIO_ROOT_USER":     accessKey,
 			"MINIO_ROOT_PASSWORD": secretKey,


### PR DESCRIPTION
When using Grill S3 for running FTs, sometimes there is a need of checking the objects stored in S3.
Minio provides a console to manage buckets / view objects.

By default, the port assigned to this console is dynamic and will vary for each container startup (https://min.io/docs/minio/linux/administration/minio-console.html#id5)

In this Change, have added cmd option to assign a static port and exposed it, which will allow access to the Minio console.
<img width="1728" alt="Screenshot 2024-09-06 at 12 21 21 AM" src="https://github.com/user-attachments/assets/9fa2e8aa-9b8c-4461-96e3-60bbf073a6be">
<img width="1728" alt="Screenshot 2024-09-06 at 12 21 35 AM" src="https://github.com/user-attachments/assets/db823b56-dbc0-4665-9d7c-0815ac09b95b">
