### PR TITLE
Nil proto check

### DIFF
--- a/action.go
+++ b/action.go
@@ -46,11 +46,10 @@ func (assert *assertOutput) Assert() error {
 				if assert.expected[i] == nil && reflect.ValueOf(assert.output[i]).IsNil() {
 					// added to check for nil proto message, as proto.Equal does not work for nil proto messages
 					continue
-				} else {
-					exp, _ := assert.expected[i].(proto.Message)
-					if !proto.Equal(out, exp) {
-						return fmt.Errorf("invalid proto message value at index=%v, got=%v, want=%v", i, assert.output[i], assert.expected[i])
-					}
+				}
+				exp, _ := assert.expected[i].(proto.Message)
+				if !proto.Equal(out, exp) {
+					return fmt.Errorf("invalid proto message value at index=%v, got=%v, want=%v", i, assert.output[i], assert.expected[i])
 				}
 			} else {
 				if !reflect.DeepEqual(assert.output[i], assert.expected[i]) {

--- a/action.go
+++ b/action.go
@@ -43,9 +43,14 @@ func (assert *assertOutput) Assert() error {
 	for i := 0; i < len(assert.output); i++ {
 		if assert.expected[i] != Any {
 			if out, ok := assert.output[i].(proto.Message); ok {
-				exp, _ := assert.expected[i].(proto.Message)
-				if !proto.Equal(out, exp) {
-					return fmt.Errorf("invalid value at index=%v, got=%v, want=%v", i, assert.output[i], assert.expected[i])
+				if assert.expected[i] == nil && reflect.ValueOf(assert.output[i]).IsNil() {
+					// added to check for nil proto message, as proto.Equal does not work for nil proto messages
+					continue
+				} else {
+					exp, _ := assert.expected[i].(proto.Message)
+					if !proto.Equal(out, exp) {
+						return fmt.Errorf("invalid proto message value at index=%v, got=%v, want=%v", i, assert.output[i], assert.expected[i])
+					}
 				}
 			} else {
 				if !reflect.DeepEqual(assert.output[i], assert.expected[i]) {

--- a/action_test.go
+++ b/action_test.go
@@ -3,6 +3,8 @@ package grill
 import (
 	"reflect"
 	"testing"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestMultiOutput(t *testing.T) {
@@ -46,6 +48,8 @@ func TestAssertOutput(t *testing.T) {
 		{"Composite-Failure", []interface{}{1, "1", &custom{1}}, []interface{}{1, "1", &custom{2}}, true},
 		{"Composite-Success", []interface{}{1, "1", &custom{1}}, []interface{}{1, "1", &custom{1}}, false},
 		{"Composite-Any", []interface{}{1, "1", &custom{1}}, []interface{}{1, "1", Any}, false},
+		{"NilProtoMessage-Success", []interface{}{getNilProtoMessage(), "1"}, []interface{}{nil, "1"}, false},
+		{"NilError-Success", []interface{}{2, getNilError()}, []interface{}{2, nil}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -56,4 +60,12 @@ func TestAssertOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getNilProtoMessage() *wrappers.StringValue {
+	return nil
+}
+
+func getNilError() error {
+	return nil
 }


### PR DESCRIPTION
In the `Assert()` function of the `action.go` file, the assertion is done using the `proto.Equal()` function if the output is a proto message. If the output is nil, this fails when the expected is set as nil.
<img width="583" alt="image" src="https://github.com/user-attachments/assets/24620083-9808-455e-9001-bffc415f0fab">
This is because the nil proto message differs from `nil` (the expected value).

This PR contains the fix for this issue, where if the output is a proto message and the expected is nil, then instead of using proto.Equal(), the code will now check if the value of the output is nil or not. 