### PR TITLE
Upgraded Wiremock Version to 3.9.2

### DIFF
--- a/canned/wiremock.go
+++ b/canned/wiremock.go
@@ -23,7 +23,7 @@ func NewWiremock(ctx context.Context) (*WireMock, error) {
 	os.Setenv("TC_HOST", "localhost")
 
 	req := testcontainers.ContainerRequest{
-		Image:        getEnvString("WIREMOCK_CONTAINER_IMAGE", "wiremock/wiremock:2.32.0"),
+		Image:        getEnvString("WIREMOCK_CONTAINER_IMAGE", "wiremock/wiremock:3.9.2"),
 		ExposedPorts: []string{"8080/tcp", "8443/tcp"},
 		WaitingFor:   wait.ForListeningPort("8080"),
 		AutoRemove:   true,


### PR DESCRIPTION
Current Version of wiremock (`2.32.0`) does not support form-data matching.
<img width="1154" alt="Screenshot 2024-10-27 at 3 43 09 PM" src="https://github.com/user-attachments/assets/c9190655-c725-4254-8ed4-30b2ad8d6fa7">

This support was added along with `3.0.0` - https://github.com/wiremock/wiremock/releases/tag/3.0.0-beta-9 / https://github.com/wiremock/wiremock/pull/2157

---

With Version `3.9.2`
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/977ce857-8f4b-4f78-9f33-fdfdea191501">
