### PR TITLE
Fix: RunParallel doesn't work the way it is supposed to

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -20,7 +20,7 @@ func RunParallel(t *testing.T, testCases []TestCase) {
 		go func(tt TestCase, wg *sync.WaitGroup) {
 			defer wg.Done()
 
-			testCase.Run(t)
+			tt.Run(t)
 		}(testCase, wg)
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -16,6 +16,7 @@ func RunParallel(t *testing.T, testCases []TestCase) {
 	wg.Add(len(testCases))
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		go func(tt TestCase, wg *sync.WaitGroup) {
 			defer wg.Done()
 

--- a/runner.go
+++ b/runner.go
@@ -16,7 +16,6 @@ func RunParallel(t *testing.T, testCases []TestCase) {
 	wg.Add(len(testCases))
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		go func(tt TestCase, wg *sync.WaitGroup) {
 			defer wg.Done()
 


### PR DESCRIPTION
### Changelog:

- testCase variable was always changing causing us to execute the same test case over and over again.