### PR TITLE
create config to change kafka assertion frequency

### DIFF
--- a/pkg/grillkafka/assertions.go
+++ b/pkg/grillkafka/assertions.go
@@ -12,7 +12,7 @@ import (
 func (gk *Kafka) AssertCount(topicName string, expectedCount int) grill.Assertion {
 	return grill.AssertionFunc(func() error {
 		group := fmt.Sprintf("%s_%d_%s", "oh_my_test_helper", rand.Intn(1000), time.Now())
-		consumer, err := gk.NewConsumer(group, topicName, time.Second*5)
+		consumer, err := gk.NewConsumer(group, topicName, time.Second)
 		if err != nil {
 			return err
 		}
@@ -33,7 +33,7 @@ func (gk *Kafka) AssertCount(topicName string, expectedCount int) grill.Assertio
 func (gk *Kafka) AssertMessageCount(topic string, message Message, expectedCount int) grill.Assertion {
 	return grill.AssertionFunc(func() error {
 		group := fmt.Sprintf("%s_%d_%s", "oh_my_test_helper", rand.Intn(1000), time.Now())
-		consumer, err := gk.NewConsumer(group, topic, time.Second*5)
+		consumer, err := gk.NewConsumer(group, topic, time.Second)
 		if err != nil {
 			return err
 		}

--- a/pkg/grillkafka/kafka_test.go
+++ b/pkg/grillkafka/kafka_test.go
@@ -52,7 +52,7 @@ func Test_GrillKafka(t *testing.T) {
 		},
 		Assertions: []grill.Assertion{
 			grill.AssertOutput(true),
-			grill.Try(time.Second*30, 3, helper.AssertCount("test_topic", 1)),
+			grill.Try(time.Second*30, 3, helper.AssertCount("test_topic", 1), grill.WithCheckFrequency(1*time.Second)),
 			grill.Try(time.Second*30, 3, helper.AssertMessageCount("test_topic_error", testMessage, 1)),
 		},
 		Cleaners: []grill.Cleaner{

--- a/try.go
+++ b/try.go
@@ -5,22 +5,38 @@ import (
 	"time"
 )
 
-func Try(deadline time.Duration, minSuccess int, assertion Assertion) Assertion {
-	return &tryAssertion{
-		assertion:  assertion,
-		deadline:   deadline,
-		minSuccess: minSuccess,
+type TryOption func(*tryAssertion)
+
+// WithCheckFrequency sets a custom frequency for assertion checks.
+// If not set, frequency is derived from deadline and minSuccess.
+func WithCheckFrequency(frequency time.Duration) TryOption {
+	return func(t *tryAssertion) {
+		t.checkFrequency = frequency
 	}
 }
 
+func Try(deadline time.Duration, minSuccess int, assertion Assertion, options ...TryOption) Assertion {
+	t := &tryAssertion{
+		assertion:      assertion,
+		deadline:       deadline,
+		minSuccess:     minSuccess,
+		checkFrequency: deadline / time.Duration(minSuccess*3+3),
+	}
+	for _, opt := range options {
+		opt(t)
+	}
+	return t
+}
+
 type tryAssertion struct {
-	assertion  Assertion
-	deadline   time.Duration
-	minSuccess int
+	assertion      Assertion
+	deadline       time.Duration
+	minSuccess     int
+	checkFrequency time.Duration
 }
 
 func (assert *tryAssertion) Assert() error {
-	checkC := time.Tick(assert.deadline / time.Duration(assert.minSuccess*3+3))
+	checkC := time.Tick(assert.checkFrequency)
 	quitC := time.Tick(assert.deadline)
 	var successCount = 0
 	var errors []string


### PR DESCRIPTION
Changes
1. Reduces frequency for assert count method from 5 to 1 to fasten assertion process
2. Creates variadic parameter in Try object to set frequency for assertion, rather than relying on deadline variable. 

The change has been tested in [central-address-service](https://github.com/swiggy-private/central-address-service/pull/464), bringing down test case runtime from 15 to 10 minute in CI pipeline. 